### PR TITLE
Modify JS test file patterns

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -44,10 +44,10 @@ const COMMENT_CHAR_MAP = {
 // file extension => regex that matches test file naming conventions
 const TEST_MATCH_MAP = {
   "rb": /_test\.rb$/,
-  "js": /-test\.js$/,
-  "jsx": /-test\.jsx$/,
-  "ts": /-test\.ts$/,
-  "tsx": /-test\.tsx$/,
+  "js": /[-.]test\.js$/,
+  "jsx": /[-.]test\.jsx$/,
+  "ts": /[-.]test\.ts$/,
+  "tsx": /[-.]test\.tsx$/,
 }
 
 const IGNORE_COMMENT_PATTERN_MAP = Object.entries(COMMENT_CHAR_MAP)


### PR DESCRIPTION
This is a modification to match a file like MyComponent.test.tsx and count it as a test file. From my browser console:

![testing the regex for tsx tests against various strings](https://github.com/glortho/pr-size-helper-action/assets/82317/6195887e-be1f-4a4c-a454-1a5a75d71624)
