### PR TITLE
Match YAML files in test/ directory as tests

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -48,6 +48,8 @@ const TEST_MATCH_MAP = {
   "jsx": /[-.]test\.jsx$/,
   "ts": /[-.]test\.ts$/,
   "tsx": /[-.]test\.tsx$/,
+  "yml": /test\/*.yml/,
+  "yaml": /test\/*.yaml/,
 }
 
 const IGNORE_COMMENT_PATTERN_MAP = Object.entries(COMMENT_CHAR_MAP)

--- a/src/constants.js
+++ b/src/constants.js
@@ -48,8 +48,8 @@ const TEST_MATCH_MAP = {
   "jsx": /[-.]test\.jsx$/,
   "ts": /[-.]test\.ts$/,
   "tsx": /[-.]test\.tsx$/,
-  "yml": /test\/*.yml/,
-  "yaml": /test\/*.yaml/,
+  "yml": /test\/**\/*.yml$/,
+  "yaml": /test\/**\/*.yaml$/,
 }
 
 const IGNORE_COMMENT_PATTERN_MAP = Object.entries(COMMENT_CHAR_MAP)


### PR DESCRIPTION
Using the [vcr gem](https://github.com/vcr/vcr), I produce YAML "cassette tape" files that have HTTP requests and responses in them. This is data I use in my tests, to avoid making actual requests to external servers during a CI build. This branch tries to target such files to treat them as tests, with the assumption that most reviewers aren't going to go through such generated files. VCR cassettes don't require a certain directory or file name pattern, so I tried to match based on being within a test/ directory and ending with either .yaml or .yml.